### PR TITLE
Update to pom-scijava 27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
 	
 	<mailingLists>
 		<mailingList>
-			<name>ImageJ Forum</name>
-			<archive>http://forum.imagej.net/</archive>
+			<name>Image.sc Forum</name>
+			<archive>https://forum.image.sc/tags/circleskinner</archive>
 		</mailingList>
 	</mailingLists>
 	

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>19.2.0</version>
+		<version>27.0.1</version>
 		<relativePath />
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,10 +83,9 @@
 	</properties>
 
 	<repositories>
-		<!-- NB: for project parent -->
 		<repository>
-			<id>imagej.public</id>
-			<url>https://maven.imagej.net/content/groups/public</url>
+			<id>scijava.public</id>
+			<url>https://maven.scijava.org/content/groups/public</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
 		<main-class>net.imagej.circleskinner.CircleSkinner</main-class>
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>My Company, Inc.</license.copyrightOwners>
-		<imagej.app.directory>../Fiji.app</imagej.app.directory>
 	</properties>
 
 	<repositories>

--- a/src/main/java/net/imagej/circleskinner/hessian/RealCompositeMatrix.java
+++ b/src/main/java/net/imagej/circleskinner/hessian/RealCompositeMatrix.java
@@ -5,11 +5,14 @@ import org.apache.commons.math3.exception.OutOfRangeException;
 import org.apache.commons.math3.linear.AbstractRealMatrix;
 import org.apache.commons.math3.linear.RealMatrix;
 
+import net.imglib2.Dimensions;
+import net.imglib2.FinalDimensions;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgFactory;
 import net.imglib2.img.list.ListImgFactory;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Util;
 import net.imglib2.view.composite.RealComposite;
 
 /**
@@ -68,12 +71,9 @@ public class RealCompositeMatrix< T extends RealType< T > > extends AbstractReal
 	public RealMatrix createMatrix( final int aNRows, final int aNCols ) throws NotStrictlyPositiveException
 	{
 		final T t = this.data.get( 0 );
-		final Img< T > img;
 		final int aLength = expectedLength( aNRows, aNCols );
-		if ( NativeType.class.isInstance( t ) )
-			img = ( ( NativeType ) t ).createSuitableNativeImg( new ArrayImgFactory<>(), new long[] { aLength } );
-		else
-			img = new ListImgFactory< T >().create( new long[] { aLength }, t );
+		final Dimensions dims = new FinalDimensions( aLength );
+		final Img< T > img = Util.getSuitableImgFactory( dims, t ).create( dims );
 
 		final RealComposite< T > aData = new RealComposite<>( img.randomAccess(), aLength );
 		return createMatrix( aData, aNRows, aNCols, aLength );


### PR DESCRIPTION
This address backwards incompatibilities in ImgLib2, and also updates `maven.imagej.net` to `maven.scijava.org`.

@tinevez I meant to file this back in May, but it somehow slipped through the cracks.